### PR TITLE
add `impl TryFrom<&str> for SvmNodes`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -13,4 +13,6 @@ pub enum Error {
     InvalidData { reason: String },
     #[error("invalid error: {reason}")]
     InternalError { reason: String },
+    #[error("invalid line: {reason}")]
+    InvalidLine { reason: String },
 }


### PR DESCRIPTION
Either of the following formats can be converted to `SvmNodes`

`index1:value1 index2:value2 ...`
  or
```
  index1:value1 index2:value2 ... \n
  index1:value1 index2:value2 ... \n
  ...
```
