### PR TITLE
[bugfix] Fix SvmPredictor::predict_with_probability() method

### DIFF
--- a/libsvm-rust/Cargo.toml
+++ b/libsvm-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsvm"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["jerry73204 <jerry73204@gmail.com>"]
 description = "High level Rust bindings for libsvm"
 edition = "2021"

--- a/libsvm-rust/Cargo.toml
+++ b/libsvm-rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsvm"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["jerry73204 <jerry73204@gmail.com>"]
 description = "High level Rust bindings for libsvm"
 edition = "2021"

--- a/libsvm-rust/src/model.rs
+++ b/libsvm-rust/src/model.rs
@@ -117,6 +117,10 @@ impl SvmTrainer {
             })?
         };
 
+        // let libsvm deal with cleaning up.
+        std::mem::forget(x_nodes);
+        std::mem::forget(x_slice);
+
         Ok(SvmPredictor {
             model_ptr,
             // nodes_opt: Some(x_nodes),

--- a/libsvm-rust/src/model.rs
+++ b/libsvm-rust/src/model.rs
@@ -482,7 +482,7 @@ impl SvmPredictor {
                 .map(|node_ptr| unsafe {
                     let n_classes = self.nr_classes();
                     let mut probability_estimates = vec![0f64; n_classes];
-                    let pred = libsvm_sys::svm_predict_values(
+                    let pred = libsvm_sys::svm_predict_probability(
                         self.model_ptr.as_ptr(),
                         node_ptr,
                         probability_estimates.as_mut_ptr(),

--- a/libsvm-rust/src/model.rs
+++ b/libsvm-rust/src/model.rs
@@ -223,7 +223,6 @@ impl SvmPredictor {
                         path: path.to_owned(),
                     })?
                     .bytes()
-                    .chain(vec![0])
                     .collect::<Vec<_>>(),
             )
             .unwrap();
@@ -254,7 +253,6 @@ impl SvmPredictor {
                         path: path.to_owned(),
                     })?
                     .bytes()
-                    .chain(vec![0])
                     .collect::<Vec<_>>(),
             )
             .unwrap();


### PR DESCRIPTION
Hi, @jerry73204 

## Bug description

[`SvmPredictor::predict_with_probability()`](https://github.com/jerry73204/libsvm-rust/blob/d1b21061541da314e46ba3c840af6810837d830b/libsvm-rust/src/model.rs#L454-L497) method incorrectly calls [`libsvm-sys::predict_values()`](https://github.com/jerry73204/libsvm-rust/blob/d1b21061541da314e46ba3c840af6810837d830b/libsvm-rust/src/model.rs#LL485C32-L485C62) at line 485, instead of [`libsvm-sys::predict_probability()`](https://github.com/jerry73204/libsvm-rust/blob/d1b21061541da314e46ba3c840af6810837d830b/libsvm-sys2/src/bindings.rs#L488-L492).

Since both of these bindings share the same signature and return type, this method thus outputs a corrupted/misleading result for users wishing to obtain probability estimates. 

## Fix

Simply change the call in [`src/model.rs:485`](https://github.com/jerry73204/libsvm-rust/blob/d1b21061541da314e46ba3c840af6810837d830b/libsvm-rust/src/model.rs#LL485C32-L485C62) from:
```Rust
    let pred = libsvm_sys::svm_predict_values(
        self.model_ptr.as_ptr(),
        node_ptr,
        probability_estimates.as_mut_ptr(),
    );
```
Into:
```Rust
    let pred = libsvm_sys::svm_predict_probability(
        self.model_ptr.as_ptr(),
        node_ptr,
        probability_estimates.as_mut_ptr(),
    );
```

Should do the trick, and will allow users to obtain sensible probability estimates.

Anyhow, hope this helps you and/or anyone stumbling into the same kind of error I had.

Cheers !